### PR TITLE
Feat/layer class

### DIFF
--- a/layer.cuh
+++ b/layer.cuh
@@ -16,5 +16,5 @@ class Layer {
         
     public:
         virtual Matrix2D forwardPass(Matrix2D &layer) = 0;
-        virtual Matrix2D backwardPass(Matrix2 &layer) = 0;
+        virtual Matrix2D backwardPass(Matrix2D &layer) = 0;
 }

--- a/layer.cuh
+++ b/layer.cuh
@@ -3,23 +3,18 @@
 using namespace matrix;
 
 /**
-* @brief Abstract base class for layer class
- */
+* @brief Abstract base class for all layers.
+* 
+* This class defines the common interface for all layers, with methods for
+* the forward and backward passes. The `layerData` matrix holds data needed
+* for gradient calculation such as input matricies, gradients, or indicies
+* depending on the layer type. 
+*/
 class Layer {
-    public: 
-        virtual ~Layer() {};
-        virtual Matrix2D forwardPass(Matrix2D &layer) = 0; 
-        virtual Matrix2D backwardPass(Matrix2D &layer) = 0;
-}
-
-/**
-* @brief Abstract base class for all gradient calculating layers
- */
-class GradientLayer : public Layer {
     protected:
-        Matrix2D inputLayer;
+        Matrix2D layerData;
         
     public:
         virtual Matrix2D forwardPass(Matrix2D &layer) = 0;
-        virtual Matrix2D backwardPass(Matrix2d &layer) = 0;
+        virtual Matrix2D backwardPass(Matrix2 &layer) = 0;
 }

--- a/layer.cuh
+++ b/layer.cuh
@@ -1,0 +1,25 @@
+#include "matrix.cuh" 
+
+using namespace matrix;
+
+/**
+* @brief Abstract base class for layer class
+ */
+class Layer {
+    public: 
+        virtual ~Layer() {};
+        virtual Matrix2D forwardPass(Matrix2D &layer) = 0; 
+        virtual Matrix2D backwardPass(Matrix2D &layer) = 0;
+}
+
+/**
+* @brief Abstract base class for all gradient calculating layers
+ */
+class GradientLayer : public Layer {
+    protected:
+        Matrix2D inputLayer;
+        
+    public:
+        virtual Matrix2D forwardPass(Matrix2D &layer) = 0;
+        virtual Matrix2D backwardPass(Matrix2d &layer) = 0;
+}


### PR DESCRIPTION
Let me know your thoughts on this.

I added a member variable for member data. We need to store the input matrix in order to calculate the gradients in the backwardPass of convolutional and fully connected layers. For other layer types like Max Pooling, we will need to store indices of the max values in order to pass the gradients later. Originally I had implemented a separate abstract class for this but I realized that 99% of layers with the exception of maybe RELU (since we technically can do this during our back propagation instead) needed some sort of extra data to back propagate. Let me know if you think this is a good strategy moving forward. Also I know I didn't templatize the class but I assume we will eventually get rid of this.